### PR TITLE
Decoupled Enums

### DIFF
--- a/src/stm32/stm32f4/cfn_hal_adc_port.c
+++ b/src/stm32/stm32f4/cfn_hal_adc_port.c
@@ -34,6 +34,15 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine ADC port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_ADC_PORT_MAX] = {
+    [CFN_HAL_ADC_PORT_ADC1] = CFN_HAL_PORT_PERIPH_ADC1,
+    [CFN_HAL_ADC_PORT_ADC2] = CFN_HAL_PORT_PERIPH_ADC2,
+    [CFN_HAL_ADC_PORT_ADC3] = CFN_HAL_PORT_PERIPH_ADC3,
+};
+
 static ADC_TypeDef *const PORT_INSTANCES[CFN_HAL_ADC_PORT_MAX] = {
 #if defined(ADC1)
     [CFN_HAL_ADC_PORT_ADC1] = ADC1,
@@ -69,7 +78,13 @@ static void low_level_init(cfn_hal_adc_t *driver)
 {
     uint32_t port_id = (uint32_t) (uintptr_t) driver->phy->instance;
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_ADC1 + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
+
+    /* 2. Initialize GPIO */
+    if (driver->phy->gpio)
+    {
+        (void) cfn_hal_gpio_init(driver->phy->gpio->port);
+    }
 }
 
 static cfn_hal_error_code_t port_base_init(cfn_hal_driver_t *base)

--- a/src/stm32/stm32f4/cfn_hal_can_port.c
+++ b/src/stm32/stm32f4/cfn_hal_can_port.c
@@ -35,6 +35,15 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine CAN port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_CAN_PORT_MAX] = {
+    [CFN_HAL_CAN_PORT_CAN1] = CFN_HAL_PORT_PERIPH_CAN1,
+    [CFN_HAL_CAN_PORT_CAN2] = CFN_HAL_PORT_PERIPH_CAN2,
+    [CFN_HAL_CAN_PORT_CAN3] = CFN_HAL_PORT_PERIPH_CAN3,
+};
+
 static CAN_TypeDef *const PORT_INSTANCES[CFN_HAL_CAN_PORT_MAX] = {
 #if defined(CAN1)
     [CFN_HAL_CAN_PORT_CAN1] = CAN1,
@@ -70,16 +79,16 @@ static void low_level_init(cfn_hal_can_t *driver)
 {
     uint32_t port_id = (uint32_t) (uintptr_t) driver->phy->instance;
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_CAN1 + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
 
     /* 2. Initialize Pins */
     if (driver->phy->tx)
     {
-        (void) cfn_hal_base_init((cfn_hal_driver_t *) driver->phy->tx, CFN_HAL_PERIPHERAL_TYPE_GPIO);
+        (void) cfn_hal_gpio_init(driver->phy->tx->port);
     }
     if (driver->phy->rx)
     {
-        (void) cfn_hal_base_init((cfn_hal_driver_t *) driver->phy->rx, CFN_HAL_PERIPHERAL_TYPE_GPIO);
+        (void) cfn_hal_gpio_init(driver->phy->rx->port);
     }
 }
 

--- a/src/stm32/stm32f4/cfn_hal_can_port.h
+++ b/src/stm32/stm32f4/cfn_hal_can_port.h
@@ -43,9 +43,8 @@ typedef enum
 {
     CFN_HAL_CAN_PORT_CAN1,
     CFN_HAL_CAN_PORT_CAN2,
-#if defined(CAN3)
     CFN_HAL_CAN_PORT_CAN3,
-#endif
+
     CFN_HAL_CAN_PORT_MAX
 } cfn_hal_can_port_t;
 

--- a/src/stm32/stm32f4/cfn_hal_dac_port.c
+++ b/src/stm32/stm32f4/cfn_hal_dac_port.c
@@ -68,7 +68,7 @@ static void low_level_init(cfn_hal_dac_t *driver)
     /* 2. Initialize Pin (Mapped via DAC channel in STM32F4) */
     if (driver->phy->pin)
     {
-        (void) cfn_hal_base_init((cfn_hal_driver_t *) driver->phy->pin, CFN_HAL_PERIPHERAL_TYPE_GPIO);
+        (void) cfn_hal_gpio_init(driver->phy->pin->port);
     }
 }
 

--- a/src/stm32/stm32f4/cfn_hal_gpio_port.c
+++ b/src/stm32/stm32f4/cfn_hal_gpio_port.c
@@ -32,6 +32,17 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine GPIO port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_GPIO_PORT_MAX] = {
+    [CFN_HAL_GPIO_PORT_A] = CFN_HAL_PORT_PERIPH_GPIOA, [CFN_HAL_GPIO_PORT_B] = CFN_HAL_PORT_PERIPH_GPIOB,
+    [CFN_HAL_GPIO_PORT_C] = CFN_HAL_PORT_PERIPH_GPIOC, [CFN_HAL_GPIO_PORT_D] = CFN_HAL_PORT_PERIPH_GPIOD,
+    [CFN_HAL_GPIO_PORT_E] = CFN_HAL_PORT_PERIPH_GPIOE, [CFN_HAL_GPIO_PORT_F] = CFN_HAL_PORT_PERIPH_GPIOF,
+    [CFN_HAL_GPIO_PORT_G] = CFN_HAL_PORT_PERIPH_GPIOG, [CFN_HAL_GPIO_PORT_H] = CFN_HAL_PORT_PERIPH_GPIOH,
+    [CFN_HAL_GPIO_PORT_I] = CFN_HAL_PORT_PERIPH_GPIOI,
+};
+
 static GPIO_TypeDef *const PORT_INSTANCES[CFN_HAL_GPIO_PORT_MAX] = {
 #if defined(GPIOA)
     [CFN_HAL_GPIO_PORT_A] = GPIOA,
@@ -70,7 +81,7 @@ static cfn_hal_error_code_t port_base_init(cfn_hal_driver_t *base)
     uint32_t        port_id = (uint32_t) (uintptr_t) driver->phy->port;
 
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_GPIOA + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
 
     return CFN_HAL_ERROR_OK;
 }

--- a/src/stm32/stm32f4/cfn_hal_i2c_port.c
+++ b/src/stm32/stm32f4/cfn_hal_i2c_port.c
@@ -35,6 +35,15 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine I2C port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_I2C_PORT_MAX] = {
+    [CFN_HAL_I2C_PORT_I2C1] = CFN_HAL_PORT_PERIPH_I2C1,
+    [CFN_HAL_I2C_PORT_I2C2] = CFN_HAL_PORT_PERIPH_I2C2,
+    [CFN_HAL_I2C_PORT_I2C3] = CFN_HAL_PORT_PERIPH_I2C3,
+};
+
 static I2C_TypeDef *const PORT_INSTANCES[CFN_HAL_I2C_PORT_MAX] = {
 #if defined(I2C1)
     [CFN_HAL_I2C_PORT_I2C1] = I2C1,
@@ -70,11 +79,17 @@ static void low_level_init(cfn_hal_i2c_t *driver)
 {
     uint32_t port_id = (uint32_t) (uintptr_t) driver->phy->instance;
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_I2C1 + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
 
     /* 2. Initialize Pins */
-    /* Note: In a real app, user would have already initialized these via pin_config */
-    CFN_HAL_UNUSED(driver);
+    if (driver->phy->sda)
+    {
+        (void) cfn_hal_gpio_init(driver->phy->sda->port);
+    }
+    if (driver->phy->scl)
+    {
+        (void) cfn_hal_gpio_init(driver->phy->scl->port);
+    }
 }
 
 static cfn_hal_error_code_t port_base_init(cfn_hal_driver_t *base)

--- a/src/stm32/stm32f4/cfn_hal_pwm_port.c
+++ b/src/stm32/stm32f4/cfn_hal_pwm_port.c
@@ -36,6 +36,19 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine Timer port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_TIMER_PORT_MAX] = {
+    [CFN_HAL_TIMER_PORT_TIM1] = CFN_HAL_PORT_PERIPH_TIM1,   [CFN_HAL_TIMER_PORT_TIM2] = CFN_HAL_PORT_PERIPH_TIM2,
+    [CFN_HAL_TIMER_PORT_TIM3] = CFN_HAL_PORT_PERIPH_TIM3,   [CFN_HAL_TIMER_PORT_TIM4] = CFN_HAL_PORT_PERIPH_TIM4,
+    [CFN_HAL_TIMER_PORT_TIM5] = CFN_HAL_PORT_PERIPH_TIM5,   [CFN_HAL_TIMER_PORT_TIM6] = CFN_HAL_PORT_PERIPH_TIM6,
+    [CFN_HAL_TIMER_PORT_TIM7] = CFN_HAL_PORT_PERIPH_TIM7,   [CFN_HAL_TIMER_PORT_TIM8] = CFN_HAL_PORT_PERIPH_TIM8,
+    [CFN_HAL_TIMER_PORT_TIM9] = CFN_HAL_PORT_PERIPH_TIM9,   [CFN_HAL_TIMER_PORT_TIM10] = CFN_HAL_PORT_PERIPH_TIM10,
+    [CFN_HAL_TIMER_PORT_TIM11] = CFN_HAL_PORT_PERIPH_TIM11, [CFN_HAL_TIMER_PORT_TIM12] = CFN_HAL_PORT_PERIPH_TIM12,
+    [CFN_HAL_TIMER_PORT_TIM13] = CFN_HAL_PORT_PERIPH_TIM13, [CFN_HAL_TIMER_PORT_TIM14] = CFN_HAL_PORT_PERIPH_TIM14,
+};
+
 static TIM_TypeDef *const PORT_INSTANCES[CFN_HAL_TIMER_PORT_MAX] = {
 #if defined(TIM1)
     [CFN_HAL_TIMER_PORT_TIM1] = TIM1,
@@ -127,12 +140,12 @@ static void low_level_init(cfn_hal_pwm_t *driver)
 {
     uint32_t port_id = (uint32_t) (uintptr_t) driver->phy->instance;
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_TIM1 + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
 
     /* 2. Initialize Pin */
     if (driver->phy->pin)
     {
-        (void) cfn_hal_base_init((cfn_hal_driver_t *) driver->phy->pin, CFN_HAL_PERIPHERAL_TYPE_GPIO);
+        (void) cfn_hal_gpio_init(driver->phy->pin->port);
     }
 }
 

--- a/src/stm32/stm32f4/cfn_hal_spi_port.c
+++ b/src/stm32/stm32f4/cfn_hal_spi_port.c
@@ -35,6 +35,15 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine SPI port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_SPI_PORT_MAX] = {
+    [CFN_HAL_SPI_PORT_1] = CFN_HAL_PORT_PERIPH_SPI1,
+    [CFN_HAL_SPI_PORT_2] = CFN_HAL_PORT_PERIPH_SPI2,
+    [CFN_HAL_SPI_PORT_3] = CFN_HAL_PORT_PERIPH_SPI3,
+};
+
 static SPI_TypeDef *const PORT_INSTANCES[CFN_HAL_SPI_PORT_MAX] = {
 #if defined(SPI1)
     [CFN_HAL_SPI_PORT_1] = SPI1,
@@ -70,10 +79,21 @@ static void low_level_init(cfn_hal_spi_t *driver)
 {
     uint32_t port_id = (uint32_t) (uintptr_t) driver->phy->instance;
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_SPI1 + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
 
     /* 2. Initialize Pins */
-    CFN_HAL_UNUSED(driver);
+    if (driver->phy->mosi)
+    {
+        (void) cfn_hal_gpio_init(driver->phy->mosi->port);
+    }
+    if (driver->phy->miso)
+    {
+        (void) cfn_hal_gpio_init(driver->phy->miso->port);
+    }
+    if (driver->phy->sck)
+    {
+        (void) cfn_hal_gpio_init(driver->phy->sck->port);
+    }
 }
 
 static cfn_hal_error_code_t port_base_init(cfn_hal_driver_t *base)

--- a/src/stm32/stm32f4/cfn_hal_timer_port.c
+++ b/src/stm32/stm32f4/cfn_hal_timer_port.c
@@ -34,6 +34,19 @@
 
 /* Private Data -----------------------------------------------------*/
 
+/**
+ * @brief Mapping from Caffeine Timer port IDs to global clock peripheral IDs.
+ */
+static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_TIMER_PORT_MAX] = {
+    [CFN_HAL_TIMER_PORT_TIM1] = CFN_HAL_PORT_PERIPH_TIM1,   [CFN_HAL_TIMER_PORT_TIM2] = CFN_HAL_PORT_PERIPH_TIM2,
+    [CFN_HAL_TIMER_PORT_TIM3] = CFN_HAL_PORT_PERIPH_TIM3,   [CFN_HAL_TIMER_PORT_TIM4] = CFN_HAL_PORT_PERIPH_TIM4,
+    [CFN_HAL_TIMER_PORT_TIM5] = CFN_HAL_PORT_PERIPH_TIM5,   [CFN_HAL_TIMER_PORT_TIM6] = CFN_HAL_PORT_PERIPH_TIM6,
+    [CFN_HAL_TIMER_PORT_TIM7] = CFN_HAL_PORT_PERIPH_TIM7,   [CFN_HAL_TIMER_PORT_TIM8] = CFN_HAL_PORT_PERIPH_TIM8,
+    [CFN_HAL_TIMER_PORT_TIM9] = CFN_HAL_PORT_PERIPH_TIM9,   [CFN_HAL_TIMER_PORT_TIM10] = CFN_HAL_PORT_PERIPH_TIM10,
+    [CFN_HAL_TIMER_PORT_TIM11] = CFN_HAL_PORT_PERIPH_TIM11, [CFN_HAL_TIMER_PORT_TIM12] = CFN_HAL_PORT_PERIPH_TIM12,
+    [CFN_HAL_TIMER_PORT_TIM13] = CFN_HAL_PORT_PERIPH_TIM13, [CFN_HAL_TIMER_PORT_TIM14] = CFN_HAL_PORT_PERIPH_TIM14,
+};
+
 static TIM_TypeDef *const PORT_INSTANCES[CFN_HAL_TIMER_PORT_MAX] = {
 #if defined(TIM1)
     [CFN_HAL_TIMER_PORT_TIM1] = TIM1,
@@ -102,7 +115,7 @@ static void low_level_init(cfn_hal_timer_t *driver)
 {
     uint32_t port_id = (uint32_t) (uintptr_t) driver->phy->instance;
     /* 1. Enable Clock */
-    cfn_hal_port_clock_enable_gate((cfn_hal_port_peripheral_id_t) (CFN_HAL_PORT_PERIPH_TIM1 + port_id));
+    cfn_hal_port_clock_enable_gate(PORT_MAP_CLOCK_PERIPHERAL_ID[port_id]);
 }
 
 static cfn_hal_error_code_t port_base_init(cfn_hal_driver_t *base)

--- a/src/stm32/stm32f4/cfn_hal_uart_port.c
+++ b/src/stm32/stm32f4/cfn_hal_uart_port.c
@@ -84,11 +84,16 @@ static const uint32_t PORT_MAP_FLOW_CONTROL[CFN_HAL_UART_CONFIG_FLOW_CTRL_MAX] =
 };
 
 static const cfn_hal_port_peripheral_id_t PORT_MAP_CLOCK_PERIPHERAL_ID[CFN_HAL_UART_PORT_MAX] = {
-    [CFN_HAL_UART_PORT_USART1] = CFN_HAL_PORT_PERIPH_USART1, [CFN_HAL_UART_PORT_USART2] = CFN_HAL_PORT_PERIPH_USART2,
-    [CFN_HAL_UART_PORT_USART3] = CFN_HAL_PORT_PERIPH_USART3, [CFN_HAL_UART_PORT_UART4] = CFN_HAL_PORT_PERIPH_UART4,
-    [CFN_HAL_UART_PORT_UART5] = CFN_HAL_PORT_PERIPH_UART5,   [CFN_HAL_UART_PORT_USART6] = CFN_HAL_PORT_PERIPH_USART6,
-    [CFN_HAL_UART_PORT_UART7] = CFN_HAL_PORT_PERIPH_UART7,   [CFN_HAL_UART_PORT_UART8] = CFN_HAL_PORT_PERIPH_UART8,
-    [CFN_HAL_UART_PORT_UART9] = CFN_HAL_PORT_PERIPH_UART9,   [CFN_HAL_UART_PORT_UART10] = CFN_HAL_PORT_PERIPH_UART10,
+    [CFN_HAL_UART_PORT_USART1] = CFN_HAL_PORT_PERIPH_USART1, // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_USART2] = CFN_HAL_PORT_PERIPH_USART2, // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_USART3] = CFN_HAL_PORT_PERIPH_USART3, // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_UART4]  = CFN_HAL_PORT_PERIPH_UART4,  // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_UART5]  = CFN_HAL_PORT_PERIPH_UART5,  // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_USART6] = CFN_HAL_PORT_PERIPH_USART6, // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_UART7]  = CFN_HAL_PORT_PERIPH_UART7,  // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_UART8]  = CFN_HAL_PORT_PERIPH_UART8,  // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_UART9]  = CFN_HAL_PORT_PERIPH_UART9,  // Useless comment, disable clang-format from wrapping
+    [CFN_HAL_UART_PORT_UART10] = CFN_HAL_PORT_PERIPH_UART10, // Useless comment, disable clang-format from wrapping
 };
 /**
  * @brief Table of physical peripheral register base addresses.
@@ -146,7 +151,7 @@ static int32_t get_port_id_from_handle(UART_HandleTypeDef *huart)
  * @brief Performs low-level hardware initialization (Clocks and GPIOs).
  * @param driver Pointer to the UART driver instance.
  */
-static enum cfn_hal_error_codes low_level_init(cfn_hal_uart_t *driver)
+static cfn_hal_error_code_t low_level_init(cfn_hal_uart_t *driver)
 {
     if (driver == NULL || driver->phy == NULL)
     {


### PR DESCRIPTION
In low_level_init, peripheral clock IDs are calculated using CFN_HAL_PORT_PERIPH_<PERIPH1> + port_id. This creates a silent, fragile dependency between the ordering of the enums. An explicit mapping array was implemented across all peripherals.

refactored the GPIO initialization in low_level_init for all applicable STM32F4 port implementations to use the refined cfn_hal_gpio_init(driver->phy->{pin}->port) pattern, replacing
  the incorrect cfn_hal_base_init casting.

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
