### PR TITLE
Fix Doxygen page, linking flags, compliance build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(FetchContent)
 FetchContent_Declare(
     caffeine-hal
     GIT_REPOSITORY https://github.com/while-one/caffeine-hal.git
-    GIT_TAG        v0.5.7
+    GIT_TAG        v0.5.8
 )
 
 FetchContent_MakeAvailable(caffeine-hal)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Then, execute your builds targeting your custom `stm32f4-mock-tests-local` prese
 
 ---
 
+## Documentation
+
+The API reference for this repository is generated automatically via Doxygen and hosted on GitHub Pages.
+
+📚 **[View the Caffeine-HAL-Ports API Documentation](https://while-one.github.io/caffeine-hal-ports)**
+
+---
+
 ## Support the Gallery
 
 While this library is no Mondrian, it deals with a different form of **abstraction art**. Hardware abstraction is a craft of its own—one that keeps your application code portable and your debugging sessions short.


### PR DESCRIPTION
- Fixed doxygen documentation in terms of the landing page. Also added a deoxygen section with link to the README file
- Updated the scripts with addtional help information
- added add_link_options(${MCU_FLAGS_LIST}) right next to add_compile_options when CMAKE_CROSSCOMPILING is true.
- For the header-only interface repositories (caffeine-hal and caffeine-sal), wrapped the caffeine-*-compliance target inside if(NOT CMAKE_CROSSCOMPILING).
- Removed compliance targets for projects that have source files, since the compliance is built in when compiling the source files

* Fix Documention section in README

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
